### PR TITLE
Darren_Branch Migrate to GCP endpoint, rewrote usage of s3upload, converted urls

### DIFF
--- a/history/historyofcg/static/js/entry.js
+++ b/history/historyofcg/static/js/entry.js
@@ -75,13 +75,13 @@ Hist.TokenInput = function() {
     return {
         init: function() {
             $("input.tokeninput").each(function () {
-                var $field = $(this), 
+                var $field = $(this),
                     options = $field.data("settings");
                 options.onReady = addCreateButton;
                 $field.tokenInput($field.data("search-url"), options);
             });
 
-            // Grab the input value before InputToken wipes it out. 
+            // Grab the input value before InputToken wipes it out.
             // Uses jQuery preBind addition from common.js
             $('.token-input-input-token-hcg input').preBind('blur', function(e) {
                 inputValue = $(this).val();
@@ -201,7 +201,7 @@ Hist.PageForm = (function() {
 // StoryForm
 /////////////
 var StoryForm = function() {
-    // Max file size is 15mb. 
+    // Max file size is 15mb.
     var MAX_FILE_SIZE = 15728640;
 
     // Validation
@@ -217,7 +217,7 @@ var StoryForm = function() {
         if ($form.find('.story-title input').val().isEmpty()) {
             errors.push("The story title is required.");
         }
-        
+
         // Check for the individual story types required fields
         if (type === "text") {
             $storyField = $form.find('.story-body textarea');
@@ -237,7 +237,7 @@ var StoryForm = function() {
             if ($urlField.val().isEmpty()) {
                 errors.push("Please upload an image before saving.");
             } else {
-                // If we have a value for our urlField then we have a file. 
+                // If we have a value for our urlField then we have a file.
                 // Grab it and check it's size again our max file size
                 file = files[0];
                 if (file.size > MAX_FILE_SIZE) {
@@ -338,14 +338,14 @@ var StoryForm = function() {
         });
     };
 
-    var s3Upload = function(e) {
+    var gcpUpload = function(e) {
         var inputId = $(this).attr('id'),
             previewImage = $(this).siblings('img');
-        var s3Upload = new S3Upload({
+        var gcpUpload = new GCPUpload({
             file_dom_selector: inputId,
-            s3_sign_put_url: '/sign_s3_upload/',
+            gcp_sign_put_url: '/sign_gcp_upload/',
             onProgress: function() {},
-            onFinishS3Put: function(url) {
+            onFinishGCPPut: function(url) {
                 Hist.Notifications.success("Successfully saved image.");
                 $('.story-image-file #id_image').val(url);
                 $(previewImage).attr('src', url);
@@ -372,7 +372,7 @@ var StoryForm = function() {
                 return false;
             });
 
-            $('input[name="story-image"]').on('change', s3Upload);
+            $('input[name="story-image"]').on('change', gcpUpload);
 
             $('.stories-col').on('click', '.story-edit-button', function(e) {
                 submitForm($(this).closest('form'), false);

--- a/history/historyofcg/static/js/libs/gcpupload.js
+++ b/history/historyofcg/static/js/libs/gcpupload.js
@@ -1,26 +1,26 @@
 (function() {
 
-  window.S3Upload = (function() {
+  window.GCPUpload = (function() {
 
-    S3Upload.prototype.s3_object_name = 'default_name';
+    GCPUpload.prototype.gcp_object_name = 'default_name';
 
-    S3Upload.prototype.s3_sign_put_url = '/signS3put';
+    GCPUpload.prototype.gcp_sign_put_url = '/signGCPput';
 
-    S3Upload.prototype.file_dom_selector = 'file_upload';
+    GCPUpload.prototype.file_dom_selector = 'file_upload';
 
-    S3Upload.prototype.onFinishS3Put = function(public_url) {
-      return console.log('base.onFinishS3Put()', public_url);
+    GCPUpload.prototype.onFinishGCPPut = function(public_url) {
+      return console.log('base.onFinishGCPPut()', public_url);
     };
 
-    S3Upload.prototype.onProgress = function(percent, status) {
+    GCPUpload.prototype.onProgress = function(percent, status) {
       return console.log('base.onProgress()', percent, status);
     };
 
-    S3Upload.prototype.onError = function(status) {
+    GCPUpload.prototype.onError = function(status) {
       return console.log('base.onError()', status);
     };
 
-    function S3Upload(options) {
+    function GCPUpload(options) {
       if (options == null) options = {};
       for (option in options) {
         this[option] = options[option];
@@ -28,7 +28,7 @@
       this.handleFileSelect(document.getElementById(this.file_dom_selector));
     }
 
-    S3Upload.prototype.handleFileSelect = function(file_element) {
+    GCPUpload.prototype.handleFileSelect = function(file_element) {
       var f, files, output, _i, _len, _results;
       this.onProgress(0, 'Upload started.');
       files = file_element.files;
@@ -41,7 +41,7 @@
       return _results;
     };
 
-    S3Upload.prototype.createCORSRequest = function(method, url) {
+    GCPUpload.prototype.createCORSRequest = function(method, url) {
       var xhr;
       xhr = new XMLHttpRequest();
       if (xhr.withCredentials != null) {
@@ -55,11 +55,11 @@
       return xhr;
     };
 
-    S3Upload.prototype.executeOnSignedUrl = function(file, callback) {
-      var this_s3upload, xhr;
-      this_s3upload = this;
+    GCPUpload.prototype.executeOnSignedUrl = function(file, callback) {
+      var this_gcpupload, xhr;
+      this_gcpupload = this;
       xhr = new XMLHttpRequest();
-      xhr.open('GET', this.s3_sign_put_url + '?s3_object_type=' + file.type + '&s3_object_name=' + this.s3_object_name, true);
+      xhr.open('GET', this.gcp_sign_put_url + '?gcp_object_type=' + file.type + '&gcp_object_name=' + this.gcp_object_name, true);
       xhr.overrideMimeType('text/plain; charset=x-user-defined');
       xhr.onreadystatechange = function(e) {
         var result;
@@ -67,40 +67,40 @@
           try {
             result = JSON.parse(this.responseText);
           } catch (error) {
-            this_s3upload.onError('Signing server returned some ugly/empty JSON: "' + this.responseText + '"');
+            this_gcpupload.onError('Signing server returned some ugly/empty JSON: "' + this.responseText + '"');
             return false;
           }
           return callback(decodeURIComponent(result.signed_request), result.url);
         } else if (this.readyState === 4 && this.status !== 200) {
-          return this_s3upload.onError('Could not contact request signing server. Status = ' + this.status);
+          return this_gcpupload.onError('Could not contact request signing server. Status = ' + this.status);
         }
       };
       return xhr.send();
     };
 
-    S3Upload.prototype.uploadToS3 = function(file, url, public_url) {
-      var this_s3upload, xhr;
-      this_s3upload = this;
+    GCPUpload.prototype.uploadToGCP = function(file, url, public_url) {
+      var this_gcpupload, xhr;
+      this_gcpupload = this;
       xhr = this.createCORSRequest('PUT', url);
       if (!xhr) {
         this.onError('CORS not supported');
       } else {
         xhr.onload = function() {
           if (xhr.status === 200) {
-            this_s3upload.onProgress(100, 'Upload completed.');
-            return this_s3upload.onFinishS3Put(public_url);
+            this_gcpupload.onProgress(100, 'Upload completed.');
+            return this_gcpupload.onFinishGCPPut(public_url);
           } else {
-            return this_s3upload.onError('Upload error: ' + xhr.status);
+            return this_gcpupload.onError('Upload error: ' + xhr.status);
           }
         };
         xhr.onerror = function() {
-          return this_s3upload.onError('XHR error.');
+          return this_gcpupload.onError('XHR error.');
         };
         xhr.upload.onprogress = function(e) {
           var percentLoaded;
           if (e.lengthComputable) {
             percentLoaded = Math.round((e.loaded / e.total) * 100);
-            return this_s3upload.onProgress(percentLoaded, percentLoaded === 100 ? 'Finalizing.' : 'Uploading.');
+            return this_gcpupload.onProgress(percentLoaded, percentLoaded === 100 ? 'Finalizing.' : 'Uploading.');
           }
         };
       }
@@ -109,15 +109,15 @@
       return xhr.send(file);
     };
 
-    S3Upload.prototype.uploadFile = function(file) {
-      var this_s3upload;
-      this_s3upload = this;
+    GCPUpload.prototype.uploadFile = function(file) {
+      var this_gcpupload;
+      this_gcpupload = this;
       return this.executeOnSignedUrl(file, function(signedURL, publicURL) {
-        return this_s3upload.uploadToS3(file, signedURL, publicURL);
+        return this_gcpupload.uploadToGCP(file, signedURL, publicURL);
       });
     };
 
-    return S3Upload;
+    return GCPUpload;
 
   })();
 

--- a/history/historyofcg/static/js/libs/gcpupload.js
+++ b/history/historyofcg/static/js/libs/gcpupload.js
@@ -56,8 +56,8 @@
     };
 
     GCPUpload.prototype.executeOnSignedUrl = function(file, callback) {
-      var this_gcpupload, xhr;
-      this_gcpupload = this;
+      var this_gcpUpload, xhr;
+      this_gcpUpload = this;
       xhr = new XMLHttpRequest();
       xhr.open('GET', this.gcp_sign_put_url + '?gcp_object_type=' + file.type + '&gcp_object_name=' + this.gcp_object_name, true);
       xhr.overrideMimeType('text/plain; charset=x-user-defined');
@@ -67,7 +67,7 @@
           try {
             result = JSON.parse(this.responseText);
           } catch (error) {
-            this_gcpupload.onError('Signing server returned some ugly/empty JSON: "' + this.responseText + '"');
+            this_gcpUpload.onError('Signing server returned some ugly/empty JSON: "' + this.responseText + '"');
             return false;
           }
           return callback(decodeURIComponent(result.signed_request), result.url);
@@ -79,28 +79,28 @@
     };
 
     GCPUpload.prototype.uploadToGCP = function(file, url, public_url) {
-      var this_gcpupload, xhr;
-      this_gcpupload = this;
+      var this_gcpUpload, xhr;
+      this_gcpUpload = this;
       xhr = this.createCORSRequest('PUT', url);
       if (!xhr) {
         this.onError('CORS not supported');
       } else {
         xhr.onload = function() {
           if (xhr.status === 200) {
-            this_gcpupload.onProgress(100, 'Upload completed.');
-            return this_gcpupload.onFinishGCPPut(public_url);
+            this_gcpUpload.onProgress(100, 'Upload completed.');
+            return this_gcpUpload.onFinishGCPPut(public_url);
           } else {
-            return this_gcpupload.onError('Upload error: ' + xhr.status);
+            return this_gcpUpload.onError('Upload error: ' + xhr.status);
           }
         };
         xhr.onerror = function() {
-          return this_gcpupload.onError('XHR error.');
+          return this_gcpUpload.onError('XHR error.');
         };
         xhr.upload.onprogress = function(e) {
           var percentLoaded;
           if (e.lengthComputable) {
             percentLoaded = Math.round((e.loaded / e.total) * 100);
-            return this_gcpupload.onProgress(percentLoaded, percentLoaded === 100 ? 'Finalizing.' : 'Uploading.');
+            return this_gcpUpload.onProgress(percentLoaded, percentLoaded === 100 ? 'Finalizing.' : 'Uploading.');
           }
         };
       }
@@ -110,10 +110,10 @@
     };
 
     GCPUpload.prototype.uploadFile = function(file) {
-      var this_gcpupload;
-      this_gcpupload = this;
+      var this_gcpUpload;
+      this_gcpUpload = this;
       return this.executeOnSignedUrl(file, function(signedURL, publicURL) {
-        return this_gcpupload.uploadToGCP(file, signedURL, publicURL);
+        return this_gcpUpload.uploadToGCP(file, signedURL, publicURL);
       });
     };
 

--- a/history/historyofcg/templates/pages/edit.html
+++ b/history/historyofcg/templates/pages/edit.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" type="text/css" href="{% static 'css/token-input-hcg.css' %}" once="1">
     <link rel="stylesheet" type="text/css" href="{% static 'css/chosen.css' %}" once="1">
 
-    <script type="text/javascript" src="{% static 'js/libs/s3upload.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/libs/gcpupload.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/libs/jquery.form.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/libs/jquery.tokeninput.min.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/libs/chosen.jquery.js' %}"></script>
@@ -41,9 +41,9 @@
                 <hr>
             </div>
             <form action="/edit/page/{{ page.vanity_url }}/"
-                  data-id="{{ page.id }}" 
+                  data-id="{{ page.id }}"
                   data-vanity-url="{{ page.vanity_url }}"
-                  method="POST" 
+                  method="POST"
                   id="entry_edit_form">
                 {% csrf_token %}
                 <div id="main-stub" class="stub section-in-form">

--- a/history/historyofcg/templates/pages/edit.html
+++ b/history/historyofcg/templates/pages/edit.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" type="text/css" href="{% static 'css/token-input-hcg.css' %}" once="1">
     <link rel="stylesheet" type="text/css" href="{% static 'css/chosen.css' %}" once="1">
 
-    <script type="text/javascript" src="{% static 'js/libs/gcpupload.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/libs/gcpUpload.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/libs/jquery.form.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/libs/jquery.tokeninput.min.js' %}"></script>
     <script type="text/javascript" src="{% static 'js/libs/chosen.jquery.js' %}"></script>

--- a/history/historyofcg/urls.py
+++ b/history/historyofcg/urls.py
@@ -8,7 +8,7 @@ admin.autodiscover()
 
 urlpatterns = patterns('history.historyofcg.views',
 
-    ## Overriding django password change views to include request, 
+    ## Overriding django password change views to include request,
     ## so this way templates will know that the user is authenticated
     url(r'^accounts/password/change/$', 'password_change'),
     url(r'^accounts/password/change/done/$', 'password_change_done'),
@@ -28,13 +28,13 @@ urlpatterns = patterns('history.historyofcg.views',
     url(r'^unpublish/page/(?P<vanity_url>[-\w]+)/$', 'unpublish_page'),
     url(r'^publish/page/(?P<vanity_url>[-\w]+)/$', 'publish_page'),
 
-    # Story URLs - AJAX 
+    # Story URLs - AJAX
     url(r'^edit/story/(?P<type>[-\w]+)/(?P<id>\d+)/$', 'edit_story'),
     url(r'^publish/story/(?P<id>\d+)/$', 'publish_story'),
     url(r'^unpublish/story/(?P<id>\d+)/$', 'unpublish_story'),
     url(r'^save/story/(?P<story_type>[-\w]+)/(?P<vanity_url>[-\w]+)/$', 'new_story'),
     url(r'^delete/story/(?P<id>\d+)/$', 'delete_story'),
-    url(r'^sign_s3_upload/$', 'sign_s3_upload'),
+    url(r'^sign_gcp_upload/$', 'sign_gcp_upload'),
 
 
     url(r'^vote/up/(?P<story_id>\d+)/$', 'up_vote_story'),
@@ -51,7 +51,7 @@ urlpatterns = patterns('history.historyofcg.views',
     url(r'^remove/connection/(?P<remove_to>[-\w]+)/(?P<to_remove>[-\w]+)/$', 'remove_connection', name='remove_connection'),
 )
 
-urlpatterns += patterns('', 
+urlpatterns += patterns('',
     # Admin URLs
     url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
     url(r'^admin/', include(admin.site.urls)),
@@ -64,7 +64,7 @@ urlpatterns += patterns('',
 
 urlpatterns += staticfiles_urlpatterns()
 
-# Add the Jasmine Test Suite URL if we're in DEBUG mode 
+# Add the Jasmine Test Suite URL if we're in DEBUG mode
 if settings.DEBUG == True:
     urlpatterns += patterns('',  url(r'^jasmine/', include('django_jasmine.urls')))
 


### PR DESCRIPTION
Made several changes:
1. Changed .env file to include GCP credentials
2. Changed S3Upload to use GCP method names
3. Upload function uses the GCP access key, password and endpoint
4. Changed s3 url to GCP
5. Add GCP settings to .env

***NOTES: I cannot test this out in my environment so this will almost definitely not work. Also, I have created the bucket in GCP with the default settings. Feel free to delete and restart: [link](https://console.cloud.google.com/storage/browser/histcg-development?project=lively-aloe-233614).***